### PR TITLE
feat: add `onInit` API on event system

### DIFF
--- a/packages/core/tests/core/event.spec.ts
+++ b/packages/core/tests/core/event.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { workflowEvent } from "@llamaindex/workflow-core";
 
 describe("event system api", () => {
@@ -10,5 +10,17 @@ describe("event system api", () => {
   test("can config unique id", () => {
     const event = workflowEvent({ uniqueId: "test" });
     expect(event.uniqueId).toBe("test");
+  });
+
+  test("callback should be called when event is initialized", () => {
+    const event = workflowEvent<number>();
+    const cb = vi.fn();
+    const cleanup = event.onInit(cb);
+    expect(cb).not.toBeCalled();
+    event.with(1);
+    expect(cb).toBeCalled();
+    cleanup();
+    event.with(2);
+    expect(cb).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
This is sth we might need to have when implement https://github.com/run-llama/workflows-ts/pull/130 (but with or)