### PR TITLE
chore: use trusted publishing for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: write # Required for pushing commits
+  pull-requests: write # Required for creating pull requests
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -18,7 +23,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
+      # Ensure npm 11.5.1 or later is installed for trusted publishing
+      - name: Update npm
+        run: npm install -g npm@latest
       - name: Install dependencies
         run: pnpm install
       - name: Generate API Documentation
@@ -31,7 +40,6 @@ jobs:
           publish: pnpm run publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update jsr.json
         run: |


### PR DESCRIPTION
DON'T merge!

Attempt to use: https://docs.npmjs.com/trusted-publishers

The following test failed:
1. added packages of this project as trusted publisher see https://docs.npmjs.com/trusted-publishers
2. used this github action

Result permission errors.

Educated guess: `changeset publish` is not using `npm publish` in the right way